### PR TITLE
Reproduce docker image fixes (pinning versions) from SWE-Bench

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -80,6 +80,7 @@ MAP_VERSION_TO_INSTALL_FLASK = {
         "packages": "requirements.txt",
         "install": "python -m pip install -e .",
         "pip_packages": [
+            "setuptools==70.0.0",
             "Werkzeug==2.3.7",
             "Jinja2==3.0.1",
             "itsdangerous==2.1.2",


### PR DESCRIPTION
This pre-emptively reproduces some of the PRs reported at SWE-bench for lacking pinned versions. List, to be updated:

- [pallets__flask-4045](https://github.com/princeton-nlp/SWE-bench/pull/204)