### PR TITLE
Fix grading of unmatched tests.

### DIFF
--- a/src/grading.py
+++ b/src/grading.py
@@ -174,9 +174,9 @@ def get_eval_report(
     results = {
         FAIL_TO_PASS: x2p + f2p,
         PASS_TO_PASS: p2p,
-        FAIL_TO_FAIL: f2f + x2x + x2f + f2x,
+        FAIL_TO_FAIL: f2f + x2f,
         PASS_TO_FAIL: p2f + p2x,
-        UNMATCHED: []
+        UNMATCHED: f2x + x2x
     }
     return results
 


### PR DESCRIPTION
#### Issue
Currently, tests that the parser does not find in the post state are always treated as failures. However, there are some instances where the parser finds spurious tests in the pre-state or added tests are skipped both before and after the fix is applied. These tests that are not found in the post state and did not pass before, should be ignored.

#### What does this implement/fix? Explain your changes.
Simply change the aggregation of tests, and include them in `UNMATCHED`.
