### PR TITLE
Fix copying too large files into docker containers

### DIFF
--- a/src/docker_build.py
+++ b/src/docker_build.py
@@ -23,7 +23,8 @@ from src.test_spec import (
 from src.docker_utils import (
     cleanup_container,
     remove_image,
-    find_dependent_images
+    find_dependent_images,
+    BuildMode,
 )
 
 from src.exec_spec import (ExecSpec,
@@ -49,7 +50,6 @@ class BuildImageError(Exception):
             f"Check ({self.log_path}) for more information."
         )
 
-BuildMode = Literal["cli", "api"]
 ExecMode = Literal["unit_test", "reproduction_script"]
 
 def docker_build_cli(

--- a/src/docker_utils.py
+++ b/src/docker_utils.py
@@ -10,9 +10,11 @@ import threading
 import traceback
 from pathlib import Path
 import tarfile
+from typing import Literal
 
 from docker.models.containers import Container
 
+BuildMode = Literal["cli", "api"]
 
 HEREDOC_DELIMITER = "EOF_1399519320"  # different from dataset HEREDOC_DELIMITERs!
 
@@ -31,7 +33,7 @@ def checked_exec_run(container: Container, cmd: str, **kwargs):
     return result
 
 
-def copy_to_container(container: Container, src: Path, dst: Path, build_mode: str = "api"):
+def copy_to_container(container: Container, src: Path, dst: Path, build_mode: BuildMode):
     """
     Copy a file from local to a docker container
 


### PR DESCRIPTION
As a remnant of cli compatability, SWT-Bench copied files into a docker container using an ugly hack that copied a file through the command line. When the file was too large, this would cause an error during execution. This bugfix resolves this issue by using the docker API for copying files into the container.